### PR TITLE
チャットルーム新規作成

### DIFF
--- a/chatapp/src/App.vue
+++ b/chatapp/src/App.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { provide, ref } from "vue"
+import { provide, ref, reactive } from "vue"
 
 // #region reactive state
 const userName = ref("")
@@ -12,7 +12,7 @@ provide("userName", userName)
 
 //ルーム用の配列
 const currentRoom = ref('soccer-club')
-const rooms = ref({
+const rooms = reactive({
   'soccer-club': {
     name: 'サッカー部全体',
     type: 'public',

--- a/chatapp/src/App.vue
+++ b/chatapp/src/App.vue
@@ -8,6 +8,56 @@ const userName = ref("")
 // #region global variable
 provide("userName", userName)
 // #endregion
+
+
+//ルーム用の配列
+const currentRoom = ref('soccer-club')
+const rooms = ref({
+  'soccer-club': {
+    name: 'サッカー部全体',
+    type: 'public',
+    icon: '🏆',
+    members: ['all']
+  },
+  'team-a': {
+    name: 'Aチーム',
+    type: 'team',
+    icon: '📁',
+    parent: 'soccer-club',
+    children: ['team-a-match-a', 'team-a-match-b'],
+    expanded: true
+  },
+  'team-a-match-a': {
+    name: '試合A',
+    type: 'match',
+    icon: '🥅',
+    parent: 'team-a'
+  },
+  'team-a-match-b': {
+    name: '試合B',
+    type: 'match',
+    icon: '🥅',
+    parent: 'team-a'
+  },
+  'team-b': {
+    name: 'Bチーム',
+    type: 'team',
+    icon: '📁',
+    parent: 'soccer-club',
+    expanded: false
+  },
+  'team-c': {
+    name: 'Cチーム',
+    type: 'team',
+    icon: '📁',
+    parent: 'soccer-club',
+    expanded: false
+  }
+})
+
+provide("currentRoom", currentRoom)
+provide("rooms", rooms)
+
 </script>
 
 <template>

--- a/chatapp/src/App.vue
+++ b/chatapp/src/App.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { provide, ref, reactive } from "vue"
+import { provide, ref,reactive } from "vue"
 
 // #region reactive state
 const userName = ref("")

--- a/chatapp/src/components/Chat.vue
+++ b/chatapp/src/components/Chat.vue
@@ -99,28 +99,69 @@ const registerSocketEvent = () => {
   })
 }
 // #endregion
+
+
+//サイドバーように追加
+const rooms = ref([])       // 作成されたルームの名前を格納
+let roomCount = 0           // カウントでルーム名生成
+
+const createRoom = () => {
+  roomCount++
+  rooms.value.push(`${roomCount}`)
+}
 </script>
 
 <template>
-  <div class="mx-auto my-5 px-4">
-    <h1 class="text-h3 font-weight-medium">Vue.js Chat チャットルーム</h1>
-    <div class="mt-10">
-      <p>ログインユーザ：{{ userName }}さん</p>
-      <textarea variant="outlined" placeholder="投稿文を入力してください" rows="4" class="area" v-model="chatContent"></textarea>
-      <div class="mt-5">
-        <button class="button-normal" @click="onPublish">投稿</button>
-        <button class="button-normal util-ml-8px" @click="onMemo">メモ</button>
-      </div>
-      <div class="mt-5" v-if="chatList.length !== 0">
-        <ul>
-          <li class="item mt-4" v-for="(chat, i) in chatList" :key="i">{{ chat }}</li>
-        </ul>
-      </div>
-    </div>
-    <router-link to="/" class="link">
-      <button type="button" class="button-normal button-exit" @click="onExit">退室する</button>
-    </router-link>
-  </div>
+  <v-container>
+    <v-row>
+      <v-col cols="3">
+        <div class="pa-4">
+          <h3>ルーム一覧</h3>
+          <v-list dense>
+            <v-list-item
+              v-for="(room, index) in rooms"
+              :key="index"
+              :to="`${room}/`"
+              tag="router-link"
+              class="room-link"
+            >
+              {{ room }}
+            </v-list-item>
+          </v-list>
+        </div>
+      </v-col>
+      <v-col cols="9">
+        <v-container>
+          <div class="mx-auto my-5 px-4">
+            <v-row>
+              <v-col cols="10">
+                <h1 class="text-h3 font-weight-medium">Vue.js Chat チャットルーム</h1>
+              </v-col>
+              <v-col cols="2">
+                <v-btn color="primary" class="button-normal" @click="createRoom">ルーム作成</v-btn>
+              </v-col>
+            </v-row>
+            <div class="mt-10">
+              <p>ログインユーザ：{{ userName }}さん</p>
+              <textarea variant="outlined" placeholder="投稿文を入力してください" rows="4" class="area" v-model="chatContent"></textarea>
+              <div class="mt-5">
+                <button class="button-normal" @click="onPublish">投稿</button>
+                <button class="button-normal util-ml-8px" @click="onMemo">メモ</button>
+              </div>
+              <div class="mt-5" v-if="chatList.length !== 0">
+                <ul>
+                  <li class="item mt-4" v-for="(chat, i) in chatList" :key="i">{{ chat }}</li>
+                </ul>
+              </div>
+            </div>
+            <router-link to="/" class="link">
+              <button type="button" class="button-normal button-exit" @click="onExit">退室する</button>
+            </router-link>
+          </div>
+        </v-container>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
 <style scoped>

--- a/chatapp/src/components/ChatWithSidebar.vue
+++ b/chatapp/src/components/ChatWithSidebar.vue
@@ -15,51 +15,37 @@ const socket = socketManager.getInstance()
 
 // #region reactive variable
 const chatContent = ref("")
+
+
 // Phase 2: ルーム別メッセージ管理
 const roomMessages = reactive(new Map()) // roomId -> messages[]
-const currentRoom = ref('soccer-club')
-const rooms = reactive({
-  'soccer-club': {
-    name: 'サッカー部全体',
-    type: 'public',
-    icon: '🏆',
-    members: ['all']
-  },
-  'team-a': {
-    name: 'Aチーム',
-    type: 'team',
-    icon: '📁',
-    parent: 'soccer-club',
-    children: ['team-a-match-a', 'team-a-match-b'],
-    expanded: true
-  },
-  'team-a-match-a': {
-    name: '試合A',
-    type: 'match',
-    icon: '🥅',
-    parent: 'team-a'
-  },
-  'team-a-match-b': {
-    name: '試合B',
-    type: 'match',
-    icon: '🥅',
-    parent: 'team-a'
-  },
-  'team-b': {
-    name: 'Bチーム',
-    type: 'team',
-    icon: '📁',
-    parent: 'soccer-club',
-    expanded: false
-  },
-  'team-c': {
-    name: 'Cチーム',
-    type: 'team',
-    icon: '📁',
-    parent: 'soccer-club',
-    expanded: false
+const currentRoom = inject("currentRoom")
+const rooms = inject("rooms")
+
+//ルーム作成
+//const new_rooms = ref([])
+const newRoomName = ref('')
+let new_roomCount = 0
+
+const createNew_Room = () => {
+  new_roomCount ++
+  const trimmedName = newRoomName.value.trim()
+  const name = trimmedName || `ルーム${new_roomCount}`
+
+  /*rooms.value.push({
+    id: `${new_roomCount}`,
+    name
+  })*/
+  const newRoomId = `custom-room-${new_roomCount}`
+  rooms.value[newRoomId] = {
+    name,
+    type: 'team', // 任意のタイプ（必要に応じて変更）
+    icon: '🆕',     // 任意のアイコン
+    parent: 'soccer-club', // 親ルームにするなら設定（必要な場合のみ）
   }
-})
+
+  newRoomName.value = ''
+}
 
 // 現在のルームのメッセージリスト（computed的に）
 const currentRoomMessages = computed(() => {
@@ -297,11 +283,34 @@ const registerSocketEvent = () => {
 </script>
 
 <template>
+  <div class="pa-4">
+      <h3>ルーム一覧</h3>
+      <v-list dense>
+        <v-list-item
+          v-for="(room, index) in rooms"
+          :key="index"
+          :to="`${room.id}/`"
+          tag="router-link"
+          class="room-link"
+        >
+        {{ room.name }}
+        </v-list-item>
+      </v-list>
+  </div>
   <div class="chat-with-sidebar">
     <Sidebar @room-changed="onRoomChange" />
     <div class="main-content">
       <div class="mx-auto my-5 px-4">
         <h1 class="text-h3 font-weight-medium">Vue.js Chat チャットルーム</h1>
+
+        <v-text-field
+          v-model="newRoomName"
+          label="新しいルーム名を入力"
+          outlined
+          dense
+          class="mb-2"
+        />
+        <button class="button-normal" @click="createNew_Room">ルーム作成</button>
         <div class="mt-10">
           <p>ログインユーザ：{{ userName }}さん</p>
           <p>現在のルーム：{{ rooms[currentRoom]?.name }} ({{ currentRoom }})</p>

--- a/chatapp/src/components/ChatWithSidebar.vue
+++ b/chatapp/src/components/ChatWithSidebar.vue
@@ -23,7 +23,6 @@ const currentRoom = inject("currentRoom")
 const rooms = inject("rooms")
 
 //ルーム作成
-//const new_rooms = ref([])
 const newRoomName = ref('')
 let new_roomCount = 0
 
@@ -31,13 +30,8 @@ const createNew_Room = () => {
   new_roomCount ++
   const trimmedName = newRoomName.value.trim()
   const name = trimmedName || `ルーム${new_roomCount}`
-
-  /*rooms.value.push({
-    id: `${new_roomCount}`,
-    name
-  })*/
   const newRoomId = `custom-room-${new_roomCount}`
-  rooms.value[newRoomId] = {
+  rooms[newRoomId] = {
     name,
     type: 'team', // 任意のタイプ（必要に応じて変更）
     icon: '🆕',     // 任意のアイコン
@@ -283,20 +277,6 @@ const registerSocketEvent = () => {
 </script>
 
 <template>
-  <div class="pa-4">
-      <h3>ルーム一覧</h3>
-      <v-list dense>
-        <v-list-item
-          v-for="(room, index) in rooms"
-          :key="index"
-          :to="`${room.id}/`"
-          tag="router-link"
-          class="room-link"
-        >
-        {{ room.name }}
-        </v-list-item>
-      </v-list>
-  </div>
   <div class="chat-with-sidebar">
     <Sidebar @room-changed="onRoomChange" />
     <div class="main-content">

--- a/chatapp/src/components/ChatWithSidebar.vue
+++ b/chatapp/src/components/ChatWithSidebar.vue
@@ -22,25 +22,6 @@ const roomMessages = reactive(new Map()) // roomId -> messages[]
 const currentRoom = inject("currentRoom")
 const rooms = inject("rooms")
 
-//ルーム作成
-const newRoomName = ref('')
-let new_roomCount = 0
-
-const createNew_Room = () => {
-  new_roomCount ++
-  const trimmedName = newRoomName.value.trim()
-  const name = trimmedName || `ルーム${new_roomCount}`
-  const newRoomId = `custom-room-${new_roomCount}`
-  rooms[newRoomId] = {
-    name,
-    type: 'team', // 任意のタイプ（必要に応じて変更）
-    icon: '🆕',     // 任意のアイコン
-    parent: 'soccer-club', // 親ルームにするなら設定（必要な場合のみ）
-  }
-
-  newRoomName.value = ''
-}
-
 // 現在のルームのメッセージリスト（computed的に）
 const currentRoomMessages = computed(() => {
   return roomMessages.get(currentRoom.value) || []
@@ -335,18 +316,9 @@ const getMessageContent = (message) => {
     <div class="main-content">
       <div class="mx-auto my-5 px-4">
         <h1 class="text-h3 font-weight-medium">Vue.js Chat チャットルーム</h1>
-
-        <v-text-field
-          v-model="newRoomName"
-          label="新しいルーム名を入力"
-          outlined
-          dense
-          class="mb-2"
-        />
-        <button class="button-normal" @click="createNew_Room">ルーム作成</button>
         <div class="mt-10">
           <p>ログインユーザ：{{ userName }}さん</p>
-          <p>現在のルーム：{{ rooms[currentRoom]?.name }} ({{ currentRoom }})</p>
+          <p>現在のルーム：{{ rooms[currentRoom]?.name }}</p>
           
           <!-- チャットメッセージ表示エリア -->
           <div class="chat-area mt-5" v-if="currentRoomMessages.length !== 0">

--- a/chatapp/src/components/Sidebar.vue
+++ b/chatapp/src/components/Sidebar.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { inject, ref, reactive, onMounted } from 'vue'
+import { inject, ref, reactive, onMounted, nextTick } from 'vue'
 
 const currentRoom = inject("currentRoom")
 const rooms = inject("rooms")
@@ -8,6 +8,56 @@ const rooms = inject("rooms")
 // 親コンポーネントに渡すイベントを定義
 const emit = defineEmits(['room-changed'])
 // #endregion
+
+//ルーム作成
+const newRoomName = ref('')
+let new_roomCount = Object.keys(rooms).length; // 既存ルーム数をカウント
+
+const createNew_Room = (name) => {
+  new_roomCount ++
+  const newRoomId = `custom-room-${new_roomCount}`
+  rooms[newRoomId] = {
+    name,
+    type: 'team', // 任意のタイプ（必要に応じて変更）
+    icon: '📁',     // 任意のアイコン
+    parent: 'soccer-club', // 親ルームにするなら設定（必要な場合のみ）
+  }
+
+  newRoomName.value = ''
+}
+
+// 状態
+const isEditing = ref(false)
+const newRoom = ref('')
+const placeholderText = 'ルーム作成'
+
+// refs
+const inputRef = ref(null)
+
+// 外部または親コンポーネントから受け取る rooms, appendRoom()
+
+// 編集開始
+function startEdit() {
+  isEditing.value = true
+  newRoom.value = ''
+  nextTick(() => {
+    inputRef.value?.focus()
+  })
+}
+
+// 入力確定時
+function handleConfirm() {
+  const name = newRoom.value.trim()
+  if (name) {
+    createNew_Room(name) // ← ここで使う！
+  }
+  isEditing.value = false
+}
+
+// 編集キャンセル（フォーカス外し）
+function cancelEdit() {
+  isEditing.value = false
+}
 
 // #region methods
 const selectRoom = (roomId) => {
@@ -88,8 +138,20 @@ onMounted(() => {
           </div>
         </div>
       </div>
+
+
+      <div v-if="isEditing" class="room-item team-level">
+        <input
+          v-model="newRoom"
+          @keyup.enter="handleConfirm"
+          @blur="cancelEdit"
+          ref="inputRef"
+        />
+      </div>
+      <div class="room-item team-level" v-else @click="startEdit">
+        {{ placeholderText }}
+      </div>
     </div>
-    <p>{{ userName }}</p>
   </div>
 
 </template>

--- a/chatapp/src/components/Sidebar.vue
+++ b/chatapp/src/components/Sidebar.vue
@@ -1,7 +1,8 @@
 <script setup>
-import { ref, reactive, onMounted } from 'vue'
+import { inject, ref, reactive, onMounted } from 'vue'
 
-const currentRoom = ref('soccer-club')
+const currentRoom = inject("currentRoom")
+// const rooms = inject("rooms")
 const rooms = reactive({
   'soccer-club': {
     name: 'サッカー部全体',
@@ -44,7 +45,6 @@ const rooms = reactive({
     expanded: false
   }
 })
-// #endregion
 
 // #region emits
 // 親コンポーネントに渡すイベントを定義
@@ -131,7 +131,9 @@ onMounted(() => {
         </div>
       </div>
     </div>
+    <p>{{ userName }}</p>
   </div>
+
 </template>
 
 <style scoped>

--- a/chatapp/src/components/Sidebar.vue
+++ b/chatapp/src/components/Sidebar.vue
@@ -2,49 +2,7 @@
 import { inject, ref, reactive, onMounted } from 'vue'
 
 const currentRoom = inject("currentRoom")
-// const rooms = inject("rooms")
-const rooms = reactive({
-  'soccer-club': {
-    name: 'サッカー部全体',
-    type: 'public',
-    icon: '🏆',
-    members: ['all']
-  },
-  'team-a': {
-    name: 'Aチーム',
-    type: 'team',
-    icon: '📁',
-    parent: 'soccer-club',
-    children: ['team-a-match-a', 'team-a-match-b'],
-    expanded: true
-  },
-  'team-a-match-a': {
-    name: '試合A',
-    type: 'match',
-    icon: '🥅',
-    parent: 'team-a'
-  },
-  'team-a-match-b': {
-    name: '試合B',
-    type: 'match',
-    icon: '🥅',
-    parent: 'team-a'
-  },
-  'team-b': {
-    name: 'Bチーム',
-    type: 'team',
-    icon: '📁',
-    parent: 'soccer-club',
-    expanded: false
-  },
-  'team-c': {
-    name: 'Cチーム',
-    type: 'team',
-    icon: '📁',
-    parent: 'soccer-club',
-    expanded: false
-  }
-})
+const rooms = inject("rooms")
 
 // #region emits
 // 親コンポーネントに渡すイベントを定義


### PR DESCRIPTION
## 概要
チャットルームの新規作成機能を修正しました。

## 実装内容
- チャットルームの情報を親コンポーネントで管理して、子コンポーネントがアクセスできるように変更

- チャットルーム作成機能を実装
今後：作成したチャットで投稿ができない（次で修正）

## 動作確認
**前**
<img width="687" height="667" alt="スクリーンショット 2025-07-31 15 52 50" src="https://github.com/user-attachments/assets/2dccbd33-7adc-43cc-a141-da214941a9a7" />

**後**
<img width="997" height="421" alt="スクリーンショット 2025-07-31 15 56 15" src="https://github.com/user-attachments/assets/597aacba-271e-4433-9f70-da279b37dcb4" />


